### PR TITLE
Fix: create wallet when user is registered

### DIFF
--- a/app/Actions/CreateWalletForUser.php
+++ b/app/Actions/CreateWalletForUser.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+readonly class CreateWalletForUser
+{
+    public function __construct(private User $user) {}
+
+    public function __invoke(User $user): User
+    {
+        if ($user->wallet()->exists()) {
+            return $user->refresh();
+        }
+
+        return DB::transaction(callback: function () use ($user): User {
+            $user->wallet()->create()->refresh();
+
+            return $user->refresh();
+        });
+    }
+}

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Auth;
 
+use App\Actions\CreateWalletForUser;
 use App\Models\User;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Http\RedirectResponse;
@@ -20,7 +21,7 @@ class RegisteredUserController
         return view('auth.register');
     }
 
-    public function store(Request $request): RedirectResponse
+    public function store(Request $request, CreateWalletForUser $createWalletForUser): RedirectResponse
     {
         $request->validate([
             'name' => ['required', 'string', 'max:255'],
@@ -33,6 +34,9 @@ class RegisteredUserController
             'email' => strtolower($request->email),
             'password' => Hash::make($request->password),
         ]);
+
+        // Create a wallet for the user
+        $createWalletForUser(user: $user);
 
         event(new Registered($user));
 

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -4,12 +4,16 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Actions\CreateWalletForUser;
 use Illuminate\Http\Request;
 
 class DashboardController
 {
-    public function __invoke(Request $request)
+    public function __invoke(Request $request, CreateWalletForUser $createWalletForUser)
     {
+        // Check if the user has a wallet, if not, create one
+        $createWalletForUser($request->user());
+        
         $transactions = $request->user()->wallet->transactions()->with('transfer')->orderByDesc('id')->get();
         $balance = $request->user()->wallet->balance;
 

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Models\User;
 use function Pest\Laravel\assertAuthenticated;
 use function Pest\Laravel\get;
 use function Pest\Laravel\post;
@@ -19,6 +20,9 @@ test('new users can register', function () {
         'password' => 'password',
         'password_confirmation' => 'password',
     ]);
+
+    $user = User::where(column: 'email', operator: '=', value: 'test@example.com')->first();
+    $this->assertTrue($user?->wallet()?->exists());
 
     assertAuthenticated();
     $response->assertRedirect(route('dashboard', absolute: false));


### PR DESCRIPTION
Where an user is registered, the wallet is not created.
- create wallet when user is registered
- create wallet when user login on Dashboard, for fix user without wallet
- add test for check wallet creation when registered